### PR TITLE
fix: RNDEAS-764: update imports for PxS 0.6

### DIFF
--- a/community/AudioThumbnail/README.md
+++ b/community/AudioThumbnail/README.md
@@ -4,9 +4,9 @@
 
 **Author(s):** Chris Oates
 
-**Version:** 1.0
+**Version:** 2.0
 
-**Last Updated:** 2018/07/06
+**Last Updated:** 2019/02/12
 
 
 ## About This Plugin

--- a/community/AudioThumbnail/audio_thumbnail.py
+++ b/community/AudioThumbnail/audio_thumbnail.py
@@ -11,7 +11,7 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 from scipy import signal
 
-from arcapix.search.metadata.plugins.thumbnails import _Thumbnail
+from arcapix.search.metadata.plugins.arcapix_core.thumbnails import _Thumbnail
 
 logger = logging.getLogger(__name__)
 

--- a/community/DocumentThumbnail/README.md
+++ b/community/DocumentThumbnail/README.md
@@ -4,9 +4,9 @@
 
 **Author(s):** Chris Oates
 
-**Version:** 1.0
+**Version:** 2.0
 
-**Last Updated:** 2018/07/06
+**Last Updated:** 2019/02/12
 
 
 ## About This Plugin

--- a/community/DocumentThumbnail/document_thumbnail.py
+++ b/community/DocumentThumbnail/document_thumbnail.py
@@ -2,7 +2,7 @@ import logging
 from PIL import Image
 from anythumbnailer.thumbnail_ import thumbnailer_for, Unoconv
 
-from arcapix.search.metadata.plugins.thumbnails import _Thumbnail
+from arcapix.search.metadata.plugins.arcapix_core.thumbnails import _Thumbnail
 from arcapix.search.metadata.utils import image_to_thumbnail, get_mimetype
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ class DocumentThumbnail(_Thumbnail):
         return (mimetype and mimetype.startswith('application/') and
                 # files which can't be identified usually return mimetype application/octet-stream
                 # so we skip these, as they're likely to fail
-                 mimetype != 'application/octet-stream')
+                mimetype != 'application/octet-stream')
 
     def _make_proxy(self, source_path, thumbnail_size):
         mimetype = get_mimetype(source_path)

--- a/community/ExtendedImageThumbnail/README.md
+++ b/community/ExtendedImageThumbnail/README.md
@@ -4,9 +4,9 @@
 
 **Author(s):** Chris Oates
 
-**Version:** 1.0
+**Version:** 2.0
 
-**Last Updated:** 2018/04/12
+**Last Updated:** 2019/02/12
 
 
 ## About This Plugin

--- a/community/ExtendedImageThumbnail/extendedimagethumbnail.py
+++ b/community/ExtendedImageThumbnail/extendedimagethumbnail.py
@@ -1,4 +1,4 @@
-from arcapix.search.metadata.plugins.thumbnails import ImageThumbnail
+from arcapix.search.metadata.plugins.arcapix_core.thumbnails import ImageThumbnail
 
 
 class ExtendedImageThumbnail(ImageThumbnail):
@@ -9,13 +9,13 @@ class ExtendedImageThumbnail(ImageThumbnail):
 
     def handles(self, ext=None, mimetype=None):
         """Override the base class handler for the image format"""
-        
+
         if super(ExtendedImageThumbnail, self).handles(ext, mimetype):
             # don't handle formats already handled by builtin plugin
             return False
 
         """Add any additional image formats to support"""
-        SUPPORTED_EXT =  ('.png', '.rgb')
+        SUPPORTED_EXT = ('.png', '.rgb')
         SUPPORTED_MIME = ('image/png', 'image/rgb', 'image/x-rgb')
-        
+
         return ext in SUPPORTED_EXT or mimetype in SUPPORTED_MIME

--- a/community/ExtendedVideoProxies/README.md
+++ b/community/ExtendedVideoProxies/README.md
@@ -4,9 +4,9 @@
 
 **Author(s):** Chris Oates
 
-**Version:** 1.0
+**Version:** 2.0
 
-**Last Updated:** 2018/07/25
+**Last Updated:** 2019/02/12
 
 
 ## About This Plugin

--- a/community/ExtendedVideoProxies/extendedvideoproxies.py
+++ b/community/ExtendedVideoProxies/extendedvideoproxies.py
@@ -1,5 +1,5 @@
-from arcapix.search.metadata.plugins.thumbnails import VideoThumbnail
-from arcapix.search.metadata.plugins.videopreview import VideoPreview
+from arcapix.search.metadata.plugins.arcapix_core.thumbnails import VideoThumbnail
+from arcapix.search.metadata.plugins.arcapix_core.videopreview import VideoPreview
 
 
 class ExtendedVideoThumbnail(VideoThumbnail):

--- a/community/HTMLThumbnail/README.md
+++ b/community/HTMLThumbnail/README.md
@@ -4,9 +4,9 @@
 
 **Author(s):** Chris Oates
 
-**Version:** 1.0
+**Version:** 2.0
 
-**Last Updated:** 2018/07/06
+**Last Updated:** 2019/02/12
 
 
 ## About This Plugin

--- a/community/HTMLThumbnail/html_thumbnail.py
+++ b/community/HTMLThumbnail/html_thumbnail.py
@@ -1,13 +1,16 @@
 import logging
 import imgkit
 
-from arcapix.search.metadata.plugins.thumbnails import _Thumbnail
+from arcapix.search.metadata.plugins.arcapix_core.thumbnails import _Thumbnail
 
 logger = logging.getLogger(__name__)
 
 
 class HtmlThumbnail(_Thumbnail):
     """Create a proxy of a specified HTML file."""
+
+    def namespace(self):
+        return "html"
 
     def handles(self, ext=None, mimetype=None):
         return (mimetype == 'text/html' or

--- a/community/TextThumbnail/README.md
+++ b/community/TextThumbnail/README.md
@@ -4,9 +4,9 @@
 
 **Author(s):** Chris Oates
 
-**Version:** 1.0
+**Version:** 2.0
 
-**Last Updated:** 2018/07/06
+**Last Updated:** 2019/02/12
 
 
 ## About This Plugin

--- a/community/TextThumbnail/text_thumbnail.py
+++ b/community/TextThumbnail/text_thumbnail.py
@@ -6,7 +6,7 @@ from bs4 import BeautifulSoup
 from itertools import ifilter
 from PIL import Image, ImageDraw, ImageFont
 
-from arcapix.search.metadata.plugins.thumbnails import _Thumbnail
+from arcapix.search.metadata.plugins.arcapix_core.thumbnails import _Thumbnail
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Core plugins have been moved in PixStor Search 0.6

Consequently, things which import from them need to be updated